### PR TITLE
[sindy] fix and wire up docs

### DIFF
--- a/docs/source/_templates/class_nomodule.rst
+++ b/docs/source/_templates/class_nomodule.rst
@@ -9,6 +9,7 @@
    {% block methods %}
    {% if objtype == "class" %}
    .. automethod:: __init__
+      :noindex:
    {% endif %}
 
    {% if methods %}

--- a/docs/source/api/index_sindy.rst
+++ b/docs/source/api/index_sindy.rst
@@ -1,0 +1,11 @@
+.. _ref-sindy:
+
+sktime.sindy
+============
+
+The *sindy* package contains the SINDy estimator for discovering governing equations from data.
+
+.. automodule:: sktime.sindy
+
+.. toctree::
+   :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,7 @@ They are structured following a possible workflow of a timeseries analysis. That
 
    api/index_base
    api/index_clustering
+   api/index_sindy
    api/index_covariance
    api/index_decomposition
    api/index_markov

--- a/sktime/sindy/__init__.py
+++ b/sktime/sindy/__init__.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 r"""
-.. currentmodule: sktime.pysindy
+.. currentmodule: sktime.sindy
 
 ===============================================================================
 Estimators
@@ -50,4 +50,4 @@ Solvers
 
 """
 
-from .sindy import SINDy, SINDyModel, STLSQ
+from ._sindy import SINDy, SINDyModel, STLSQ

--- a/sktime/sindy/_sindy.py
+++ b/sktime/sindy/_sindy.py
@@ -46,7 +46,7 @@ class SINDy(Estimator):
         Parameters
         ----------
         library : library object, optional, default=None
-            The candidate feature library, :math:`Theta`.
+            The candidate feature library, :math:`\Theta`.
             The object should implement a :meth:`fit`, :meth:`transform`,
             and :meth:`get_feature_names` methods. It should also have
             :attr:`n_input_features_` and :attr:`n_output_features_` attributes.
@@ -157,7 +157,7 @@ class SINDyModel(Model):
         Parameters
         ----------
         library : library object
-            The feature library, :math:`Theta`.
+            The feature library, :math:`\Theta`.
             It is assumed that this object has already been fit to the input data.
             The object should implement  :meth:`transform`
             and :meth:`get_feature_names` methods.
@@ -377,14 +377,14 @@ class STLSQ(LinearRegression):
     by iteratively performing least squares and masking out
     elements of the weight that are below a given threshold.
 
-    See this paper for more details :cite:`sindy-brunton-2016`.
+    See this paper for more details :cite:`sindy-stlsq-brunton-2016`.
 
     References
     ----------
     .. bibliography:: /references.bib
         :style: unsrt
         :filter: docname in docnames
-        :keyprefix: sindy-
+        :keyprefix: sindy-stlsq-
     """
 
     def __init__(


### PR DESCRIPTION
- moved file `sindy.py` to `_sindy.py` as sphinx does not like when there is a python module file within a module directory of the same name
- added sindy to the documentation index
- minor docfix